### PR TITLE
Example Polyfill

### DIFF
--- a/example_polyfill.js
+++ b/example_polyfill.js
@@ -1,0 +1,53 @@
+if (!Symbol.matches) {
+  const DEFINE_PROPERTY = "defineProperty";
+
+  // define Symbol.matches
+  Object[DEFINE_PROPERTY](Symbol, "matches", {
+    configurable: false,
+    writable: false,
+    value: Symbol("matches"),
+  });
+
+  function defineMatch(O, fn) {
+    Object[DEFINE_PROPERTY](O, Symbol.matches, {
+      writable:     false,
+      configurable: false,
+      enumerable:   false,
+      value:        fn
+    });
+  }
+
+  // Classes
+  defineMatch(Function.prototype, function (x) {
+    return x instanceof this;
+  });
+
+  // Primitive Classes
+  defineMatch(Number, function (x) {
+    return typeof x === "number";
+  });
+  defineMatch(String, function (x) {
+    return typeof x === "string";
+  });
+  defineMatch(Boolean, function (x) {
+    return typeof x === "boolean";
+  });
+
+  // RegExp
+  defineMatch(RegExp.prototype, function (x) {
+    return this.test(x);
+  });
+
+  // Sets
+  defineMatch(Set.prototype, function (x) {
+    return this.has(x);
+  });
+}
+
+function isMatch(pattern, x) {
+  return Boolean(
+    x != null && pattern != null && Symbol.matches in pattern
+    ? pattern[Symbol.matches](x)
+    : x === pattern
+  );
+}


### PR DESCRIPTION
Intended as a starting-point for a concrete notion of what matches what. There are a few points that I don't expect would function like this. 

Note that `isMatch` checks for `===` when `[Symbol.matches]` is not defined, including for numeric/string/boolean/null/void literals.