### PR TITLE
Make #17 a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ LiteralMatchPattern :
   // number, string, boolean, null, or undefined literal
 ```
 
-The syntax of object and array patterns deliberately hews closely to destructuring which is advantageous for a couple reasons. First, it aligns with existing syntax that developers are familiar with. Second, it allows pattern matching and destructuring to be used in similar contexts (for example, future proposals for multi-methods or the like). However, pattern matching JavaScript values requires in practice requires more expressive power than simple destructuring gives us. This proposal adds additional patterns to fill the gaps. It may be reasonable to depart further from destructuring to increase the utility and expressiveness of this proposal (e.g. something like #17).
+The syntax of object and array patterns deliberately hews closely to destructuring which is advantageous for a couple reasons. First, it aligns with existing syntax that developers are familiar with. Second, it allows pattern matching and destructuring to be used in similar contexts (for example, future proposals for multi-methods or the like). However, pattern matching JavaScript values requires in practice requires more expressive power than simple destructuring gives us. This proposal adds additional patterns to fill the gaps. It may be reasonable to depart further from destructuring to increase the utility and expressiveness of this proposal (e.g. something like [#17](https://github.com/tc39/proposal-pattern-matching/issues/17)).
 
 ## Object Patterns
 Object patterns match objects with certain properties. Additional properties may be present on the matched object. Examples:


### PR DESCRIPTION
Using just `#17` works in issues, comments, and commits, but unfortunately this syntax doesn't auto-link in a README. This change makes the #17 reference in the Syntax Sketch section explicitly link to issue 17.