### PR TITLE
Remove unused assignment from code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ matcher"](#object-matcher) to run different code depending on the value of
 `response.status`.
 
 ```js
-const response = await fetch(someUrl)
 console.log(match (await fetch(someUrl)) {
   {status: 200} => 'request succeeded!',
   {status: 404} => 'no value at url!',


### PR DESCRIPTION
This line seems to have been copied from the following example, and the assigned value is never used.

An alternative edit could be to use `response` as a parameter to `match` in the next line to make the surrounding references to `response.status` clearer, but using an intermittent variable like this isn't really the style of the rest of the document so I didn't do it that way.