### PR TITLE
Fix typo in code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ function todoApp (state = initialState, action) {
     }),
 
     {} => null // ignore unknown actions
-  })
+  }
 
   return {...state, ...newState}
 }


### PR DESCRIPTION
Removed stray `)` in code example.