### PR TITLE
Return state by default in Redux reducer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ function todoApp (state = initialState, action) {
         )
       }
     }
-    when {} -> {} // ignore unknown actions
+    when {} -> { // just return state for unknown actions
+      return state
+    }
   }
 }
 ```


### PR DESCRIPTION
The state must be returned by default in Redux reducers.