### PR TITLE
docs: Tweak React examples for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,15 +232,20 @@ More concise, more functional handling of Redux reducers. Compare with [this sam
 ```jsx
 function todoApp(state = initialState, action) {
   return match (action) {
-    when ({ type: 'set-visibility-filter', filter: visFilter }) {
+    when ({ type: 'set-visibility-filter', payload: visFilter }) {
       ({ ...state, visFilter });
     }
-    when ({ type: 'add-todo', text }) {
-      ({ ...state, todos: [...state.todos, { text }] });
+    when ({ type: 'add-todo', payload: text }) {
+      ({ ...state, todos: [...state.todos, { text, completed: false }] });
     }
-    when ({ type: 'toggle-todo', index }) {
-      let newTodos = state.todos;
-      newTodos[index].done = !newTodos[index].done;
+    when ({ type: 'toggle-todo', payload: index }) {
+      const newTodos = state.todos.map((todo, i) => {
+        return i !== index ? todo : {
+          ...todo,
+          completed: !todo.completed
+        };
+      });
+
       ({
         ...state,
         todos: newTodos,


### PR DESCRIPTION
This is very minor, but I think the two changes here would help clarify how one could use this syntax with React.

R.e. the Redux example, this aligns the example with what's in the Redux docs, as their docs use the `{ action, payload }` signature. It also updates the example so that it doesn't modify the state, which the Redux example does as well.

~R.e. the `<Fetch>` example, given that the pattern requires that the key exist on the matched value, and since it's a safe assumption that the prop keys will be consistent, one would need to spread the `...rest` props in order for the pattern to match.~